### PR TITLE
feat: add pathOverride option to remap request paths (v1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The `initialize` method takes two arguments:
     - `disableUserIdStorage` - A boolean indicating whether or not to store the provided user id in storage. Defaults to `false`
     - `blockCommonBots` - A boolean indicating whether or not to block common bots from being tracked. Defaults to `true`
     - `anonymousIdOverride` - A string value to be used as the anonymous id of the device the user is on.
-    - `endpoint` - A string value used as the base path for sending events to, useful in case you need to proxy events through a server. Defaults to `https://integration-api.userflux.co`.
+    - `endpoint` - A string value used as the base path for sending events to, useful in case you need to proxy events through a server. Must include the scheme (e.g. `https://`) — a value without one will be resolved relative to the current page. Defaults to `https://integration-api.userflux.co`.
+    - `pathOverride` - An object used to remap the request path (subroute) for one or more routes, useful when proxying events and you also need to mask the path (e.g. to avoid path-based ad/privacy blocking). Keys are the canonical UserFlux paths and values are the path you want the SDK to send to instead. The two overridable routes are `event/ingest/batch` (events) and `profile` (identify). Defaults to no overrides. For example, with `endpoint: 'https://events.example.com'` and `pathOverride: { 'event/ingest/batch': 'h/a', 'profile': 'h/b' }`, events are sent to `https://events.example.com/h/a?locationEnrichment=...`. Your proxy must forward the request (including the `locationEnrichment` query string) to the matching UserFlux path.
 
 ## 3. Tracking events
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class UserFlux {
 	static ufMaxConsecutiveFailures = 3
 	static ufRetryDelay = 1000 // 1 second delay between retries
 	static ufEndpoint = "https://integration-api.userflux.co"
+	static ufPathOverrides = {}
 
 	static initialize(apiKey, options) {
 		try {
@@ -32,6 +33,18 @@ class UserFlux {
 
 			if ("endpoint" in options && typeof options["endpoint"] === "string") {
 				UserFlux.ufEndpoint = options["endpoint"]
+				if (!/^https?:\/\//i.test(UserFlux.ufEndpoint)) {
+					console.info("UF: endpoint should include a scheme e.g. https:// — requests may resolve relative to the current page.")
+				}
+			}
+
+			if (
+				"pathOverride" in options &&
+				typeof options["pathOverride"] === "object" &&
+				options["pathOverride"] !== null &&
+				!Array.isArray(options["pathOverride"])
+			) {
+				UserFlux.ufPathOverrides = options["pathOverride"]
 			}
 
 			if ("allowCookies" in options && options["allowCookies"] == true) {
@@ -707,7 +720,15 @@ class UserFlux {
 		}
 
 		try {
-			await fetch(`${UserFlux.ufEndpoint}/${endpoint}?locationEnrichment=${locationEnrich}`, {
+			// `endpoint` here is the request path/subroute. Allow it to be remapped via
+			// pathOverride (e.g. for first-party proxies masking analytics paths), falling
+			// back to the canonical path when no valid override is provided.
+			const override = UserFlux.ufPathOverrides[endpoint]
+			const resolvedPath = UserFlux.isStringNullOrBlank(override) ? endpoint : override
+			const base = UserFlux.ufEndpoint.replace(/\/+$/, "")
+			const path = resolvedPath.replace(/^\/+/, "")
+
+			await fetch(`${base}/${path}?locationEnrichment=${locationEnrich}`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@userflux/browser-js",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@userflux/browser-js",
-			"version": "1.6.0",
+			"version": "1.7.0",
 			"license": "ISC",
 			"dependencies": {
 				"cross-fetch": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@userflux/browser-js",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "UserFlux's JavaScript SDK - send your frontend analytics data to the UserFlux platform",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
## Context

v1.6.0 added the `endpoint` option so customers can proxy UserFlux events through their own domain to dodge browser ad/privacy blockers that match on the request **host**.

A customer (Humanitix) runs a first-party proxy and observed that blockers can also match on the request **path** (`/event/ingest/batch` looks like analytics). Their proxy already rewrites a benign path like `/h/a` → UserFlux's `/event/ingest/batch`, but the SDK hard-coded the path, so it still emitted the tell-tale route. This adds a per-route path override so they can mask it.

```js
UserFlux.initialize(apiKey, {
    endpoint: "https://events.humanitix.com",
    pathOverride: { "event/ingest/batch": "h/a", "profile": "h/b" }
})
// → POST https://events.humanitix.com/h/a?locationEnrichment=...
```

## Changes

- **`pathOverride` option** — a map of canonical path → replacement path. The two overridable routes are `event/ingest/batch` (events) and `profile` (identify). Resolved in the single `sendRequest` chokepoint, with a safe fallback to the canonical path when a key is missing or the value is blank/non-string. Existing installs (no `pathOverride`) behave identically.
- **Slash normalisation** when building the URL, so a leading-slash override (`"/h/a"`) or a trailing-slash `endpoint` can't produce `//`.
- **Missing-scheme warning** — `console.info` if `endpoint` is set without `https://`. A schemeless value resolves relative to the page and silently 404s (a 404 doesn't throw), which is exactly how a proxying customer would break their integration.
- **Docs** — documented both options in the README; strengthened the `endpoint` note to require the scheme.
- **Version** — bumped `1.6.0` → `1.7.0` (additive, backward-compatible).

## Testing

No test harness exists in the repo (`npm test` is a stub). Verified with a throwaway Node harness that stubbed `cross-fetch` and asserted the exact request URLs — 13 cases all passed:

- override hit / miss → canonical / blank → canonical
- leading-slash and trailing-slash normalisation (no `//`)
- `profile` route override; default endpoint unchanged with no overrides
- `initialize` guard matrix (`null` / array rejected; `{}` and a populated map accepted)
- scheme warning fires only when the scheme is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)